### PR TITLE
Fixing Elm steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ and so on.
 
 ### Elm
 * elm 0.19.0 (https://guide.elm-lang.org/install.html)
+* elm-test 0.19.0-rev3 (https://www.npmjs.com/package/elm-test)
 
 ### Elixir
 * elixir 1.7.4 (http://elixir-lang.org/install.html)
@@ -64,6 +65,6 @@ To test your setup, run the tests for each exercise on the command line once you
 * clojure - run `lein test` from clojure/prime_factors
 * haskell - run `stack install` from the haskell folder and then `stack test`
 * rust - run `cargo test` in the rust folder
-* elm - run `elm test` in the elm folder
+* elm - run `elm-test` in the elm folder
 * elixir - run `mix test` from elixir/prime_factors
 * go - run `ginkgo` from the go folder


### PR DESCRIPTION
Hi!

When I tried to test my Elm setup (having installed 0.19.0) I got the following error:

```
$ elm test
There is no test command. Try repl or init instead?

Run `elm` with no arguments to get more hints.
```

I was able to get the tests running by installing and running `elm-test`.

Full disclosure: I'm a complete newbie when it comes to Elm, so I'm not sure if these steps will be appropriate for everyone. I'm running Ubuntu 18.04.

Looking forward to Wednesday's session!
